### PR TITLE
[1847AE] Altered logic for draft round

### DIFF
--- a/lib/engine/game/g_1847_ae/round/draft.rb
+++ b/lib/engine/game/g_1847_ae/round/draft.rb
@@ -7,8 +7,12 @@ module Engine
     module G1847AE
       module Round
         class Draft < Engine::Round::Draft
+          def setup
+            next_entity! unless active_step
+          end
+
           def next_entity_index!
-            # First round of draft is perforemd in reverse player order, then it must be reversed back to normal
+            # First round of draft is performed in reverse player order, then it must be reversed back to normal
             if @entity_index == @entities.size - 1 && @reverse_order
               @entities.reverse!
               @reverse_order = false
@@ -17,39 +21,30 @@ module Engine
             super
           end
 
-          def process_action(action, suppress_log = false)
-            type = action.type
-            clear_cache!
+          def after_process(_action)
+            return if active_step
 
-            before_process(action)
-
-            step = @steps.find do |s|
-              next unless s.active?
-
-              process = s.actions(action.entity).include?(type)
-              blocking = s.blocking?
-
-              raise GameError, "Blocking step #{s.description} cannot process action #{action.id}" if blocking && !process
-
-              blocking || process
-            end
-
-            raise GameError, "No step found for action #{type} at #{action.id}: #{action.to_h}" unless step
-
-            step.acted = true
-            step.send("process_#{action.type}", action, suppress_log)
-
-            @at_start = false
-
-            after_process_before_skip(action)
-            skip_steps
-            clear_cache!
-            after_process(action)
+            next_entity!
           end
 
-          def reset_entity_index!
-            @game.next_turn!
-            @entity_index = (@entity_index + 1) % @entities.size
+          def next_entity!
+            next_entity_index!
+            if finished?
+              @game.draft_finished = all_drafted?
+              return
+            end
+
+            @steps.each(&:unpass!)
+            skip_steps
+            next_entity! unless active_step
+          end
+
+          def all_drafted?
+            @game.companies.all? { |c| c.owner || c.closed? }
+          end
+
+          def finished?
+            all_drafted? || @entities.all?(&:passed)
           end
         end
       end


### PR DESCRIPTION
Moved as much of the round flow control code from `Step::Draft` into `Round::Draft`.

This has removed the need for the duplication of `Round.process_action` and the insertion of a pass action for the next player in the draft step.

This has only been minimally tested. The `Round::Draft.setup` code is for when the player with priority deal cannot afford a company at the start of a round, but I have not tested this works correctly.